### PR TITLE
CARBON-15654: Changed the generate goal to accept none OSGi versions for bundles

### DIFF
--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/feature/generate/Bundle.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/feature/generate/Bundle.java
@@ -24,7 +24,7 @@ import org.wso2.maven.p2.utils.BundleUtils;
  */
 public class Bundle extends CarbonArtifact {
     /**
-     * Returns the OSGI content in a string format.
+     * Returns the OSGi content in a string format.
      * <p>
      * {symbolic name} : {bundle version}
      * </p>
@@ -35,6 +35,11 @@ public class Bundle extends CarbonArtifact {
         return getSymbolicName() + ":" + getBundleVersion();
     }
 
+    /**
+     * Returns the OSGi version of the bundle.
+     *
+     * @return String
+     */
     public String getOSGIVersion() {
         return BundleUtils.getOSGIVersion(super.getVersion());
     }

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/feature/generate/Bundle.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/feature/generate/Bundle.java
@@ -17,6 +17,7 @@
 package org.wso2.maven.p2.feature.generate;
 
 import org.wso2.maven.p2.beans.CarbonArtifact;
+import org.wso2.maven.p2.utils.BundleUtils;
 
 /**
  * Bean class representing a Bundle object provided as an input param to FeatureGenMojo.
@@ -32,5 +33,9 @@ public class Bundle extends CarbonArtifact {
      */
     public String toOSGIString() {
         return getSymbolicName() + ":" + getBundleVersion();
+    }
+
+    public String getOSGIVersion() {
+        return BundleUtils.getOSGIVersion(super.getVersion());
     }
 }

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/feature/generate/FeatureGenerator.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/feature/generate/FeatureGenerator.java
@@ -144,7 +144,7 @@ public class FeatureGenerator {
      */
     private void populateBundleDataFromCache() throws CarbonArtifactNotFoundException {
         for (Bundle bundle : resourceBundle.getBundles()) {
-            String key = bundle.getSymbolicName() + "_" + bundle.getVersion();
+            String key = bundle.getSymbolicName() + "_" + bundle.getOSGIVersion();
             CarbonArtifact artifact = dependentBundles.get(key);
             if (artifact == null) {
                 throw new CarbonArtifactNotFoundException("Bundle " + key + " is not found in project dependency list");


### PR DESCRIPTION
Currently to generate a feature from an OSGi bundle, the generate mojo of carbon feature plugin accept only OSGi version. Improve this to work for none osgi version as well.
i.e: The plugin used to accept versions like 1.2.4.SNAPSHOT. Now the plugin should support 1.2.4-SNAPSHOT as well.

This PR incorporate the aforementioned enhancement.
