### PR TITLE
Dynamic Product file support

### DIFF
--- a/carbon-feature-plugin/pom.xml
+++ b/carbon-feature-plugin/pom.xml
@@ -48,6 +48,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>javax.xml</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
         </dependency>

--- a/carbon-feature-plugin/pom.xml
+++ b/carbon-feature-plugin/pom.xml
@@ -19,14 +19,14 @@
     <parent>
         <groupId>org.wso2.carbon.maven</groupId>
         <artifactId>carbon-maven-plugins</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>carbon-feature-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
     <name>Carbon Maven Plugins - Carbon Feature Plugin</name>
 
     <dependencies>

--- a/carbon-feature-plugin/pom.xml
+++ b/carbon-feature-plugin/pom.xml
@@ -19,14 +19,14 @@
     <parent>
         <groupId>org.wso2.carbon.maven</groupId>
         <artifactId>carbon-maven-plugins</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>carbon-feature-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
     <name>Carbon Maven Plugins - Carbon Feature Plugin</name>
 
     <dependencies>

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/ConfigIni.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/ConfigIni.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product;
+
+import org.wso2.maven.p2.utils.P2Constants;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent configInit data.
+ *
+ * This is used to
+ * [1] Capture build-time configInit data from distribution pom file.
+ * [2] Write configIni data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class ConfigIni {
+
+    private String use = P2Constants.ProductFileDefaults.Product.CONFIG_INI_USE;
+
+    public String getUse() {
+        return use;
+    }
+
+    @XmlAttribute
+    public void setUse(String use) {
+        this.use = use;
+    }
+
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Configurations.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Configurations.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent configurations.
+ *
+ * This is used write configurations data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class Configurations {
+
+    private List<Plugin> plugins;
+
+    private List<Property> properties;
+
+    @SuppressWarnings("unused")
+    public Configurations() {}
+
+    public Configurations(List<Plugin> plugin, List<Property> property) {
+        this.setPlugins(plugin);
+        this.setProperties(property);
+    }
+
+    public List<Plugin> getPlugins() {
+        return plugins;
+    }
+
+    @XmlElement(name = "plugin")
+    public void setPlugins(List<Plugin> plugins) {
+        this.plugins = plugins;
+    }
+
+    public List<Property> getProperties() {
+        return properties;
+    }
+
+    @XmlElement(name = "property")
+    public void setProperties(List<Property> properties) {
+        this.properties = properties;
+    }
+
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Feature.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Feature.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product;
+
+import org.wso2.maven.p2.utils.P2Constants;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent an individual feature.
+ *
+ * This is used to
+ * [1] Capture build-time product file individual feature data from distribution pom file.
+ * [2] Write individual feature data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class Feature {
+
+    private String id;
+
+    private String version;
+
+    public Feature() {}
+
+    public Feature(String id, String version) {
+        this.setId(id);
+        this.setVersion(version);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @XmlAttribute
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    @XmlAttribute
+    public void setVersion(String version) {
+        if (version == null || version.isEmpty() ||
+                !version.contains(P2Constants.ProductFileDefaults.Feature.VERSION_CHAR_REPLACED)) {
+            this.version = version;
+        } else {
+            this.version = version.replaceAll(P2Constants.ProductFileDefaults.Feature.VERSION_CHAR_REPLACED,
+                    P2Constants.ProductFileDefaults.Feature.VERSION_CHAR_REPLACEMENT);
+        }
+    }
+
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Features.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Features.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent features.
+ *
+ * This is used to write features data to
+ * carbon.product file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class Features {
+
+    private List<Feature> features;
+
+    @SuppressWarnings("unused")
+    public Features() {}
+
+    public Features(List<Feature> features) {
+        this.setFeatures(features);
+    }
+
+    public List<Feature> getFeatures() {
+        return features;
+    }
+
+    @XmlElement(name = "feature")
+    public void setFeatures(List<Feature> features) {
+        this.features = features;
+    }
+
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Launcher.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Launcher.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product;
+
+import org.wso2.maven.p2.utils.P2Constants;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent launcher data.
+ *
+ * This is used to
+ * [1] Capture build-time product file launcher data from distribution pom file.
+ * [2] Write launcher data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class Launcher {
+
+    private String name = P2Constants.ProductFileDefaults.Product.LAUNCHER_NAME;
+
+    public String getName() {
+        return name;
+    }
+
+    @XmlAttribute(name = "name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/LauncherArgs.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/LauncherArgs.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent launcher arguments.
+ *
+ * This is used to
+ * [1] Capture build-time product file launcher argument data from distribution pom file.
+ * [2] Write launcher argument data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class LauncherArgs { }

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Plugin.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Plugin.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent a plugin.
+ *
+ * This is used to
+ * [1] Capture build-time product file individual plugin data from distribution pom file.
+ * [2] Write individual plugin data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class Plugin {
+
+    private String id;
+
+    private Boolean autoStart;
+
+    private Integer startLevel;
+
+    public Plugin() {}
+
+    public Plugin(String id, Boolean autoStart, Integer startLevel) {
+        this.setId(id);
+        this.setAutoStart(autoStart);
+        this.setStartLevel(startLevel);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @XmlAttribute
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @SuppressWarnings("unused")
+    public Boolean getAutoStart() {
+        return autoStart;
+    }
+
+    @XmlAttribute
+    public void setAutoStart(Boolean autoStart) {
+        this.autoStart = autoStart;
+    }
+
+    @SuppressWarnings("unused")
+    public Integer getStartLevel() {
+        return startLevel;
+    }
+
+    @XmlAttribute
+    public void setStartLevel(Integer startLevel) {
+        this.startLevel = startLevel;
+    }
+
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Plugins.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Plugins.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent plugins.
+ *
+ * This is used to
+ * [1] Capture build-time product file plugin data from distribution pom file.
+ * [2] Write plugin data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class Plugins { }

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Product.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Product.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product;
+
+import org.wso2.maven.p2.beans.carbon.product.config.ProductConfig;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent a product.
+ *
+ * This is used to write product data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class Product extends ProductConfig {
+
+    private Features features;
+
+    private Configurations configurations;
+
+    public Features getFeatures() {
+        return features;
+    }
+
+    @XmlElement
+    public void setFeatures(Features features) {
+        this.features = features;
+    }
+
+    @SuppressWarnings("unused")
+    public Configurations getConfigurations() {
+        return configurations;
+    }
+
+    @XmlElement
+    public void setConfigurations(Configurations configurations) {
+        this.configurations = configurations;
+    }
+
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Property.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/Property.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent a property.
+ *
+ * This is used to
+ * [1] Capture build-time product file property data from distribution pom file.
+ * [2] Write property data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class Property {
+
+    private String name;
+
+    private Boolean value;
+
+    @SuppressWarnings("unused")
+    public Property() {}
+
+    public Property(String name, Boolean value) {
+        this.setName(name);
+        this.setValue(value);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @XmlAttribute
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Boolean getValue() {
+        return value;
+    }
+
+    @XmlAttribute
+    public void setValue(Boolean value) {
+        this.value = value;
+    }
+
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/config/ProductConfig.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/config/ProductConfig.java
@@ -1,0 +1,229 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product.config;
+
+import org.wso2.maven.p2.beans.carbon.product.ConfigIni;
+import org.wso2.maven.p2.beans.carbon.product.Feature;
+import org.wso2.maven.p2.beans.carbon.product.Launcher;
+import org.wso2.maven.p2.beans.carbon.product.LauncherArgs;
+import org.wso2.maven.p2.beans.carbon.product.Plugin;
+import org.wso2.maven.p2.beans.carbon.product.Plugins;
+import org.wso2.maven.p2.beans.carbon.product.Property;
+import org.wso2.maven.p2.utils.P2Constants;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+/**
+ * Bean to represent product configurations.
+ *
+ * This is used to capture build-time product configuration
+ * data from distribution pom file.
+ *
+ * @since 3.1.0
+ */
+
+@XmlRootElement
+public class ProductConfig {
+
+    private String name = P2Constants.ProductFileDefaults.Product.NAME;
+
+    private String uid = P2Constants.ProductFileDefaults.Product.UID;
+
+    private String id = P2Constants.ProductFileDefaults.Product.ID;
+
+    private String application = P2Constants.ProductFileDefaults.Product.APPLICATION;
+
+    private String version; // If not set in project pom, carbon runtime version will be set by default.
+
+    private Boolean useFeatures = P2Constants.ProductFileDefaults.Product.USE_FEATURES;
+
+    private Boolean includeLaunchers = P2Constants.ProductFileDefaults.Product.INCLUDE_LAUNCHERS;
+
+    private ConfigIni configIni = new ConfigIni();
+
+    private LauncherArgs launcherArgs = new LauncherArgs();
+
+    private Launcher launcher = new Launcher();
+
+    private Plugins plugins = new Plugins();
+
+    private List<Feature> featureConfig; // If not set in project pom, carbon runtime feature will be set by default.
+
+    private List<Plugin> pluginConfig = this.getDefaultPluginConfig();
+
+    private List<Property> propertyConfig = this.getDefaultPropertyConfig();
+
+    public String getName() {
+        return name;
+    }
+
+    @XmlAttribute
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUid() {
+        return uid;
+    }
+
+    @XmlAttribute
+    public void setUid(String uid) {
+        this.uid = uid;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @XmlAttribute
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    @XmlAttribute
+    public void setApplication(String application) {
+        this.application = application;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    @XmlAttribute
+    public void setVersion(String version) {
+        if (version == null || version.isEmpty() ||
+                !version.contains(P2Constants.ProductFileDefaults.Feature.VERSION_CHAR_REPLACED)) {
+            this.version = version;
+        } else {
+            this.version = version.replaceAll(P2Constants.ProductFileDefaults.Feature.VERSION_CHAR_REPLACED,
+                    P2Constants.ProductFileDefaults.Feature.VERSION_CHAR_REPLACEMENT);
+        }
+    }
+
+    public Boolean getUseFeatures() {
+        return useFeatures;
+    }
+
+    @XmlAttribute
+    public void setUseFeatures(Boolean useFeatures) {
+        this.useFeatures = useFeatures;
+    }
+
+    public Boolean getIncludeLaunchers() {
+        return includeLaunchers;
+    }
+
+    @XmlAttribute
+    public void setIncludeLaunchers(Boolean includeLaunchers) {
+        this.includeLaunchers = includeLaunchers;
+    }
+
+    public ConfigIni getConfigIni() {
+        return configIni;
+    }
+
+    @XmlElement
+    public void setConfigIni(ConfigIni configIni) {
+        this.configIni = configIni;
+    }
+
+    public LauncherArgs getLauncherArgs() {
+        return launcherArgs;
+    }
+
+    @XmlElement
+    public void setLauncherArgs(LauncherArgs launcherArgs) {
+        this.launcherArgs = launcherArgs;
+    }
+
+    public Launcher getLauncher() {
+        return launcher;
+    }
+
+    @XmlElement
+    public void setLauncher(Launcher launcher) {
+        this.launcher = launcher;
+    }
+
+    public Plugins getPlugins() {
+        return plugins;
+    }
+
+    @XmlElement
+    public void setPlugins(Plugins plugins) {
+        this.plugins = plugins;
+    }
+
+    public List<Feature> getFeatureConfig() {
+        return featureConfig;
+    }
+
+    @XmlTransient
+    public void setFeatureConfig(List<Feature> featureConfig) {
+        this.featureConfig = featureConfig;
+    }
+
+    public List<Plugin> getPluginConfig() {
+        return pluginConfig;
+    }
+
+    @XmlTransient
+    @SuppressWarnings("unused")
+    public void setPluginConfig(List<Plugin> pluginConfig) {
+        this.pluginConfig = pluginConfig;
+    }
+
+    public List<Property> getPropertyConfig() {
+        return propertyConfig;
+    }
+
+    @XmlTransient
+    @SuppressWarnings("unused")
+    public void setPropertyConfig(List<Property> propertyConfig) {
+        this.propertyConfig = propertyConfig;
+    }
+
+    private List<Property> getDefaultPropertyConfig() {
+        List<Property> properties = new ArrayList<>();
+        // adding default property, value pairs
+        properties.add(new Property("org.eclipse.update.reconcile", false));
+        properties.add(new Property("org.eclipse.equinox.simpleconfigurator.useReference", true));
+        return properties;
+    }
+
+    private List<Plugin> getDefaultPluginConfig() {
+        List<Plugin> plugins = new ArrayList<>();
+        // adding default plugins wth default autoStart and startLevel configurations
+        plugins.add(new Plugin("org.eclipse.core.runtime", true, 4));
+        plugins.add(new Plugin("org.eclipse.equinox.common", true, 2));
+        plugins.add(new Plugin("org.eclipse.equinox.ds", true, 2));
+        plugins.add(new Plugin("org.eclipse.equinox.p2.reconciler.dropins", true, 4));
+        plugins.add(new Plugin("org.eclipse.equinox.simpleconfigurator", true, 1));
+        plugins.add(new Plugin("org.eclipse.update.configurator", true, 1));
+        return plugins;
+    }
+
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/config/ProductFileConfig.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/carbon/product/config/ProductFileConfig.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.carbon.product.config;
+
+import org.wso2.maven.p2.utils.P2Constants;
+
+/**
+ * Bean to represent build-time product file configurations.
+ *
+ * This is used to capture build-time product file configuration
+ * data from distribution pom file.
+ *
+ * @since 3.1.0
+ */
+
+public class ProductFileConfig {
+
+    private Float pdeVersion = P2Constants.ProductFileDefaults.PDE_VERSION;
+
+    private ProductConfig productConfig = new ProductConfig();
+
+    public Float getPdeVersion() {
+        return pdeVersion;
+    }
+
+    @SuppressWarnings("unused")
+    public void setPdeVersion(Float pdeVersion) {
+        this.pdeVersion = pdeVersion;
+    }
+
+    public ProductConfig getProductConfig() {
+        return productConfig;
+    }
+
+    @SuppressWarnings("unused")
+    public void setProductConfig(ProductConfig productConfig) {
+        this.productConfig = productConfig;
+    }
+
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/profile/GenerateProfileMojo.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/profile/GenerateProfileMojo.java
@@ -27,6 +27,7 @@ import org.eclipse.tycho.model.ProductConfiguration;
 import org.wso2.maven.p2.utils.FileManagementUtil;
 import org.wso2.maven.p2.utils.P2ApplicationLaunchManager;
 import org.wso2.maven.p2.utils.P2Constants;
+import org.wso2.maven.p2.utils.ProductFileUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -99,9 +100,15 @@ public class GenerateProfileMojo extends AbstractMojo {
         }
     }
 
-    private void deployRepository() throws MojoFailureException, IOException {
-        ProductConfiguration productConfiguration = ProductConfiguration.read(productConfigurationFile);
-        P2ApplicationLaunchManager p2LaunchManager = new P2ApplicationLaunchManager(this.launcher);
+    private void deployRepository() throws MojoFailureException, MojoExecutionException, IOException {
+        ProductConfiguration productConfiguration;
+        if (productConfigurationFile != null) {
+            productConfiguration = ProductConfiguration.read(productConfigurationFile);
+        } else {
+            File productFile = ProductFileUtils.readFile(project);
+            productConfiguration = ProductConfiguration.read(productFile);
+        }
+        P2ApplicationLaunchManager p2LaunchManager = new P2ApplicationLaunchManager(launcher);
         p2LaunchManager.setWorkingDirectory(project.getBasedir());
         p2LaunchManager.setApplicationName("org.eclipse.equinox.p2.director");
         p2LaunchManager.addGenerateProfileArguments(repositoryURL, productConfiguration.getId(), runtime, targetPath);

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/P2Constants.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/P2Constants.java
@@ -50,5 +50,37 @@ public class P2Constants {
         public static final String INSTALLIU = "-installIU";
     }
 
+    /**
+     * Constants class related to product file default settings.
+     */
+    public static class ProductFileDefaults {
+        public static final String NAME = "carbon.product";
+        public static final String TARGET_DIRECTORY = "target";
+        public static final Float PDE_VERSION = 3.5F;
+
+        /**
+         * Constants class related to Product element default settings of product file.
+         */
+        public static class Product {
+            public static final String NAME = "Carbon Product";
+            public static final String UID = "carbon.product.id";
+            public static final String ID = "carbon.product";
+            public static final String APPLICATION = "carbon.application";
+            public static final String RUNTIME_FEATURE = "org.wso2.carbon.runtime";
+            public static final Boolean USE_FEATURES = true;
+            public static final Boolean INCLUDE_LAUNCHERS = true;
+            public static final String CONFIG_INI_USE = "default";
+            public static final String LAUNCHER_NAME = "eclipse";
+        }
+
+        /**
+         * Constants class related to default character replacement settings of
+         * version values appearing in a product file.
+         */
+        public static class Feature {
+            public static final String VERSION_CHAR_REPLACEMENT = ".";
+            public static final String VERSION_CHAR_REPLACED = "-";
+        }
+    }
 
 }

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/ProductFileUtils.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/ProductFileUtils.java
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.utils;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.wso2.maven.p2.beans.carbon.product.Configurations;
+import org.wso2.maven.p2.beans.carbon.product.Feature;
+import org.wso2.maven.p2.beans.carbon.product.Features;
+import org.wso2.maven.p2.beans.carbon.product.Product;
+import org.wso2.maven.p2.beans.carbon.product.config.ProductConfig;
+import org.wso2.maven.p2.beans.carbon.product.config.ProductFileConfig;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+
+/**
+ * Utility class for helper functions in generating and reading a product file at build-time.
+ *
+ * This class is to be used by publish-product and generate-runtime maven goals.
+ *
+ * @since 3.1.0
+ */
+public class ProductFileUtils {
+
+    /**
+     * Write Product bean as an XML to a product file.
+     *
+     * @param productFileConfig productFileConfig bean as read from project pom.
+     * @param mavenProject mavenProject bean as read from project pom.
+     * @throws javax.xml.bind.JAXBException Is thrown if an error occurs in writing configurations into product file.
+     */
+    public static void writeToFile(ProductFileConfig productFileConfig,
+                                   MavenProject mavenProject) throws JAXBException, MojoExecutionException {
+        // validating version and featureConfig values captured from project pom
+        ProductConfig validatedProductConfig = ProductFileUtils.
+                validateProductConfigForVersionAndFeatureConfig(productFileConfig.getProductConfig(), mavenProject);
+
+        // populating a product instance with validated values for writing to a product file
+        Product product = new Product();
+
+        product.setName(validatedProductConfig.getName());
+        product.setUid(validatedProductConfig.getUid());
+        product.setId(validatedProductConfig.getId());
+        product.setApplication(validatedProductConfig.getApplication());
+        product.setVersion(validatedProductConfig.getVersion());
+        product.setUseFeatures(validatedProductConfig.getUseFeatures());
+        product.setIncludeLaunchers(validatedProductConfig.getIncludeLaunchers());
+        product.setVersion(validatedProductConfig.getVersion());
+        product.setConfigIni(validatedProductConfig.getConfigIni());
+        product.setLauncherArgs(validatedProductConfig.getLauncherArgs());
+        product.setLauncher(validatedProductConfig.getLauncher());
+        product.setPlugins(validatedProductConfig.getPlugins());
+
+        Features features = new Features(validatedProductConfig.getFeatureConfig());
+        Configurations configurations = new Configurations(validatedProductConfig.getPluginConfig(),
+                validatedProductConfig.getPropertyConfig());
+
+        product.setFeatures(features);
+        product.setConfigurations(configurations);
+
+        // writing to a product file
+        JAXBContext jaxbContext = JAXBContext.newInstance(Product.class);
+        Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+
+        jaxbMarshaller.setProperty("com.sun.xml.bind.xmlHeaders",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<?pde version=\"" +
+                        productFileConfig.getPdeVersion() + "\"?>");
+        jaxbMarshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
+        jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+        File productFile = new File(ProductFileUtils.
+                getAbsoluteFilePath(mavenProject), P2Constants.ProductFileDefaults.NAME);
+        jaxbMarshaller.marshal(product, productFile);
+        jaxbMarshaller.marshal(product, System.out);
+    }
+
+    /**
+     * Read dynamically generated product file as a new file instance.
+     *
+     * @param mavenProject mavenProject bean as read from distribution pom.
+     * @return A product file.
+     */
+    public static File readFile(MavenProject mavenProject) throws MojoExecutionException {
+        return new File(ProductFileUtils.
+                getAbsoluteFilePath(mavenProject), P2Constants.ProductFileDefaults.NAME);
+    }
+
+    private static ProductConfig
+    validateProductConfigForVersionAndFeatureConfig(ProductConfig productConfig, MavenProject mavenProject)
+            throws MojoExecutionException {
+
+        if (productConfig.getVersion() == null) {
+            productConfig.setVersion(ProductFileUtils.getDependencyVersion(mavenProject,
+                    P2Constants.ProductFileDefaults.Product.RUNTIME_FEATURE));
+        }
+        if (productConfig.getFeatureConfig() == null) {
+            productConfig.setFeatureConfig(ProductFileUtils.getDefaultFeatureConfig(mavenProject));
+        }
+
+        return productConfig;
+    }
+
+    private static List<Feature> getDefaultFeatureConfig(MavenProject mavenProject) throws MojoExecutionException {
+        List<Feature> features = new ArrayList<>();
+        // adding default features with versions
+        features.add(new Feature(P2Constants.ProductFileDefaults.Product.RUNTIME_FEATURE,
+                ProductFileUtils.getDependencyVersion(mavenProject,
+                        P2Constants.ProductFileDefaults.Product.RUNTIME_FEATURE)));
+        return features;
+    }
+
+    private static String getDependencyVersion(MavenProject mavenProject,
+                                               String dependency) throws MojoExecutionException {
+        if (mavenProject == null) {
+            throw new MojoExecutionException("Unable to read maven project for finding dependencies.");
+        } else if (dependency == null || dependency.isEmpty()) {
+            throw new MojoExecutionException("Unable to find version for invalid dependency value.");
+        } else {
+            Artifact artifact = mavenProject.getDependencyArtifacts().stream().
+                    filter(a -> a.getArtifactId().contains(dependency)).findFirst().orElse(null);
+            if (artifact == null) {
+                throw new MojoExecutionException("Unable to find version as there seems to be " +
+                        "no pom based configuration for the provided dependency.");
+            }
+            String dependencyVersion = artifact.getBaseVersion();
+            if (dependencyVersion == null || dependencyVersion.isEmpty()) {
+                throw new MojoExecutionException("Unable to find version for the provided dependency.");
+            }
+            return dependencyVersion;
+        }
+    }
+
+    private static String getAbsoluteFilePath(MavenProject mavenProject) throws MojoExecutionException {
+        if (mavenProject == null) {
+            throw new MojoExecutionException("Unable to read maven project for finding project path.");
+        } else {
+            return mavenProject.getBasedir().getAbsolutePath() + File.separator +
+                    P2Constants.ProductFileDefaults.TARGET_DIRECTORY;
+        }
+    }
+
+}

--- a/docs/CarbonFeaturePlugin.md
+++ b/docs/CarbonFeaturePlugin.md
@@ -52,6 +52,227 @@ A sample pom.xml file configuration of the `generate` Maven goal is shown below.
 
  NOT MANDATORY.
  Example: `<deleteOldRuntimeFiles>false</deleteOldRuntimeFiles>`.
+ 
+### Configuring the publish-product Maven goal
+
+A sample pom.xml file configuration of the `publish-product` Maven goal is shown below.
+
+      <execution>
+                <id>publishing products</id>
+                <phase>package</phase>
+                <goals>
+                        <goal>publish-product</goal>
+                </goals>
+                <configuration>
+                        <!-- configurations related to this goal go under here -->
+                                <!-- [1] product file related configurations : 
+                                
+                                        You can keep no configuration at all for this which would mean that
+                                        plugin will generate a temporary product file during build-time with default 
+                                        settings. But if <productConfigurationFile> element is present, that 
+                                        will override any other configuration related to a product file and use any 
+                                        already existing (static) product file located at a path specified as value 
+                                        of the element. For example, please refer to the following. -->
+                                        
+                                            <productConfigurationFile>
+                                                    ${basedir}/carbon.product
+                                            </productConfigurationFile>
+
+                                        <!-- following is optional and can be used if customization 
+                                        is required for a dynamically generated product file during build-time. -->
+                                        
+                                            <productFileConfig>
+                                                    <!-- see `productFileConfig` section for 
+                                                    available customization options -->
+                                            </productFileConfig>
+                                        
+                                <!-- [2] product-publishing executable related configurations : -->
+                                
+                                            <executable>
+                                                    <!-- executable path is given here. -->
+                                            </executable>
+                                        
+                                <!-- [3] Carbon feature repository based configurations : -->
+                                
+                                            <repositoryURL>
+                                                    <!-- Carbon feature repository path is given here. -->
+                                            </repositoryURL>
+                </configuration>
+      </execution>
+      
+You can add any mandatory or optional configuration elements related to this goal under \<configuration\> element as depicted above.
+In the meantime, each element is described as follows.
+ 
+1. `productConfigurationFile`: With respect to product file related configurations, this element is mandatory if you are choosing to refer 
+    to any already existing (static) product file in publishing the product. The element will contain absolute path to such product file as value.
+    
+    Note: You can instead go ahead with referring to a dynamically generated product file during build-time in achieving "publish-product" goal.
+    This can be achieved by having no configurations at all in the pom, so that a product file will be dynamically generated during build-time with
+    default settings. This is an improvement added to carbon-feature-plugin such that no further manual intervention is required in updating 
+    a statically maintained product file during build-time for the release process as in the case of \<productConfigurationFile\> setting.
+    
+2. `productFileConfig`: This is an optional configuration that you can set if and only if customization is required for a 
+    dynamically generated product file during build-time over provided default settings.
+    
+    Available customization options:
+    
+    \<productFileConfig\>
+    
+        <!-- [1] pdeVersion (Number): Default value is 3.5. -->
+        <pdeVersion>.....</pdeVersion>
+        
+        <productConfig>
+        
+                <!-- [2] name (String): If not set, default value is 'Carbon Product'. -->
+                <name>.....</name>
+            
+                <!-- [3] uid (String): If not set, default value is 'carbon.product.id'. -->
+                <uid>.....</uid>
+            
+                <!-- [4] application (String): If not set, default value is 'carbon.application'. -->
+                <application>.....</application>
+                
+                <!-- [5] version (String): If not set, carbon runtime version will be taken as default value. -->
+                <version>.....</version>
+            
+                <!-- [6] useFeatures (true or false): If not set, default value is 'true'. -->
+                <useFeatures>.....</useFeatures>
+            
+                <!-- [7] includeLaunchers (true or false): If not set, default value is 'true'. -->
+                <includeLaunchers>.....</includeLaunchers>
+                
+                <!-- [8] configIni: If not set, default value for use is 'default'. -->
+                <configIni>
+                        <use>.....</use>
+                </configIni>
+                
+                <!-- [9] launcher: If not set, default value for name is 'eclipse'. -->
+                <launcher>
+                        <name>eclipse</name>
+                </launcher>
+                
+                <!-- [10] featureConfig: If not set, by default, 
+                featureConfig will hold 'org.wso2.carbon.runtime' feature. -->
+                <featureConfig>
+                        <feature>
+                                <id>.....</id>
+                                <version>.....</version>
+                        </feature>
+                        .....
+                </featureConfig>
+                
+                <!-- [11] pluginConfig: If not set, by default, 
+                pluginConfig will hold 6 plugins, namely org.eclipse.core.runtime, org.eclipse.equinox.common,
+                org.eclipse.equinox.ds, org.eclipse.equinox.p2.reconciler.dropins, org.eclipse.equinox.simpleconfigurator,
+                and org.eclipse.update.configurator. -->
+                <pluginConfig>
+                        <plugin>
+                                <id>.....</id>
+                                <autoStart>.....</autoStart>
+                                <startLevel>.....</startLevel>
+                        </plugin>
+                        .....                    
+                        <plugin></plugin>
+                </pluginConfig>
+                
+                <!-- [12] propertyConfig: If not set, by default, 
+                propertyConfig will hold 2 properties, namely org.eclipse.update.reconcile and 
+                org.eclipse.update.recon. -->
+                <propertyConfig>
+                        <property>
+                                <name>.....</name>
+                                <value>.....</value>
+                        </property>
+                        .....
+                </propertyConfig>
+        </productConfig>
+        
+    \</productFileConfig\>
+    
+4. `executable`: product-publishing executable related configurations.
+
+        <executable>
+                <!-- product-publishing executable path is given here. -->
+        </executable>
+    
+5. `repositoryURL`: Carbon feature repository based configurations.
+
+        <repositoryURL>
+                <!-- Carbon feature repository path is given here. -->
+        </repositoryURL>
+
+### Configuring the generate-runtime Maven goal
+
+A sample pom.xml file configuration of the `generate-runtime` Maven goal is shown below.
+
+      <execution>
+                <id>materialize-product</id>
+                <phase>package</phase>
+                <goals>
+                        <goal>generate-runtime</goal>
+                </goals>
+                <configuration>
+                        <!-- configurations related to this goal go under here -->
+                                <!-- [1] product file related configurations : 
+                                
+                                In here, you can either have no configuration at all or
+                                <productConfigurationFile> setting.
+                                
+                                <productConfigurationFile> element is mandatory 
+                                if you are choosing to refer to any already existing (static) product file 
+                                in generating a runtime. The element will contain absolute path to 
+                                such product file as value. 
+                                
+                                And, having no configuration would mean that you are referring to a dynamically
+                                generated product file during build-time in generating a runtime.
+                                
+                                        <productConfigurationFile>
+                                                ${basedir}/carbon.product
+                                        </productConfigurationFile>
+                                        
+                                        <!-- or nothing. -->
+                                        
+                                <!-- [2] Carbon feature repository based configurations : -->
+                                        <repositoryURL>
+                                                <!-- Carbon feature repository path is given here. -->
+                                        </repositoryURL>
+                                
+                                <!-- [3] Target location for the carbon features to be copied in server pack : -->
+                                        <targetPath>
+                                                <!-- Target location for the carbon features to be copied 
+                                                in server pack is given here. -->
+                                        </targetPath>
+                                        
+                                <!-- [4] Runtime type : -->
+                                        <runtime>
+                                                <!-- Runtime type is given here. -->
+                                        </runtime>
+                </configuration>
+      </execution>
+      
+You can add any mandatory or optional configuration elements related to this goal under \<configuration\> element as depicted above.
+In the meantime, each element is described as follows.
+
+1. `productConfigurationFile`: With respect to product file related configurations, this element is mandatory if you are choosing to refer 
+    to any statically existing product file in generating-runtime. The element will contain absolute path to such product file with the name of the file.
+    
+2. `repositoryURL`: Carbon feature repository based configurations.
+
+        <repositoryURL>
+                <!-- Carbon feature repository path is given here. -->
+        </repositoryURL>
+        
+3. `targetPath`: Target location for the carbon features to be copied in server pack.
+
+        <targetPath>
+                <!-- Target location for the carbon features to be copied in server pack is given here. -->
+        </targetPath>
+    
+4. `runtime`: Runtime type.
+    
+        <runtime>
+                <!-- Runtime type is given here. -->
+        </runtime>
 
 ### Configuring the uninstall Maven goal
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>javax.xml</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb.impl.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>
                 <artifactId>maven-plugin-annotations</artifactId>
                 <version>${maven.plugin.annotation.version}</version>
@@ -115,6 +120,7 @@
         <tycho.version>0.25.0</tycho.version>
         <org.apache.maven.project.version>2.2.1</org.apache.maven.project.version>
         <junit.version>3.8.1</junit.version>
+        <jaxb.impl.version>2.1</jaxb.impl.version>
         <maven.plugin.plugin.version>3.4</maven.plugin.plugin.version>
         <maven.plugin.annotation.version>3.3</maven.plugin.annotation.version>
         <org.eclipse.equinox.p2.engine.version>2.3.0.v20140506-1720</org.eclipse.equinox.p2.engine.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>org.wso2.carbon.maven</groupId>
     <artifactId>carbon-maven-plugins</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
     <name>Carbon Maven Plugins - Parent Pom</name>
     <url>http://wso2.org</url>
 
@@ -33,7 +33,7 @@
         <url>https://github.com/wso2/carbon-maven-plugins.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-maven-plugins.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-maven-plugins.git</connection>
-        <tag>v3.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>org.wso2.carbon.maven</groupId>
     <artifactId>carbon-maven-plugins</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
     <name>Carbon Maven Plugins - Parent Pom</name>
     <url>http://wso2.org</url>
 
@@ -33,7 +33,7 @@
         <url>https://github.com/wso2/carbon-maven-plugins.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-maven-plugins.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-maven-plugins.git</connection>
-        <tag>HEAD</tag>
+        <tag>v3.0.0</tag>
     </scm>
 
     <modules>


### PR DESCRIPTION
This feature resolves #56 and adds an improvement to carbon-feature-plugin in supporting
a dynamically generated product file for the reference of publish-product and generate-runtime maven goals. A dynamically generated product file during build-time overcomes the issue of having to manually update a statically maintained product file with version-bumps for a release-build, thus contributing to a fully-automated release process.