### PR TITLE
Dynamic Product file support

### DIFF
--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/ConfigIni.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/ConfigIni.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.product;
+
+import org.wso2.maven.p2.utils.P2Constants;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent configInit data.
+ *
+ * This is used to
+ * [1] Capture build-time configInit data from distribution pom file.
+ * [2] Write configIni data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+@XmlRootElement
+public class ConfigIni {
+
+    private String use = P2Constants.ProductFile.Product.CONFIG_INI_USE;
+
+    public String getUse() {
+        return use;
+    }
+
+    @XmlAttribute
+    public void setUse(String use) {
+        this.use = use;
+    }
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Configurations.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Configurations.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.product;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent configurations.
+ *
+ * This is used write configurations data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+@XmlRootElement
+public class Configurations {
+
+    private List<Plugin> plugins;
+    private List<Property> properties;
+
+    @SuppressWarnings("unused")
+    public Configurations() {}
+
+    public Configurations(List<Plugin> plugin, List<Property> property) {
+        this.setPlugins(plugin);
+        this.setProperties(property);
+    }
+
+    public List<Plugin> getPlugins() {
+        return plugins;
+    }
+
+    @XmlElement(name = "plugin")
+    public void setPlugins(List<Plugin> plugins) {
+        this.plugins = plugins;
+    }
+
+    public List<Property> getProperties() {
+        return properties;
+    }
+
+    @XmlElement(name = "property")
+    public void setProperties(List<Property> properties) {
+        this.properties = properties;
+    }
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Launcher.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Launcher.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.product;
+
+import org.wso2.maven.p2.utils.P2Constants.ProductFile.Product;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent launcher data.
+ *
+ * This is used to
+ * [1] Capture build-time product file launcher data from distribution pom file.
+ * [2] Write launcher data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+@XmlRootElement
+public class Launcher {
+
+    private String name = Product.LAUNCHER_NAME;
+
+    public String getName() {
+        return name;
+    }
+
+    @XmlAttribute
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Plugin.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Plugin.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.product;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent a plugin.
+ *
+ * This is used to
+ * [1] Capture build-time product file individual plugin data from distribution pom file.
+ * [2] Write individual plugin data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+@XmlRootElement
+public class Plugin {
+
+    private String id;
+    private Boolean autoStart;
+    private Integer startLevel;
+
+    public Plugin() {}
+
+    public Plugin(String id, Boolean autoStart, Integer startLevel) {
+        this.setId(id);
+        this.setAutoStart(autoStart);
+        this.setStartLevel(startLevel);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @XmlAttribute
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @SuppressWarnings("unused")
+    public Boolean getAutoStart() {
+        return autoStart;
+    }
+
+    @XmlAttribute
+    public void setAutoStart(Boolean autoStart) {
+        this.autoStart = autoStart;
+    }
+
+    @SuppressWarnings("unused")
+    public Integer getStartLevel() {
+        return startLevel;
+    }
+
+    @XmlAttribute
+    public void setStartLevel(Integer startLevel) {
+        this.startLevel = startLevel;
+    }
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Product.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Product.java
@@ -17,7 +17,9 @@
 package org.wso2.maven.p2.beans.product;
 
 import org.wso2.maven.p2.beans.product.config.ProductConfig;
+import org.wso2.maven.p2.utils.P2Constants;
 
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -31,7 +33,19 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 public class Product extends ProductConfig {
 
+    private Boolean useFeatures = P2Constants.ProductFile.Product.USE_FEATURES;
     private Configurations configurations;
+
+    @SuppressWarnings("unused")
+    public Boolean getUseFeatures() {
+        return useFeatures;
+    }
+
+    @XmlAttribute
+    @SuppressWarnings("unused")
+    public void setUseFeatures(Boolean useFeatures) {
+        this.useFeatures = useFeatures;
+    }
 
     @SuppressWarnings("unused")
     public Configurations getConfigurations() {

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Product.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Product.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.product;
+
+import org.wso2.maven.p2.beans.product.config.ProductConfig;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent a product.
+ *
+ * This is used to write product data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+@XmlRootElement
+public class Product extends ProductConfig {
+
+    private Configurations configurations;
+
+    @SuppressWarnings("unused")
+    public Configurations getConfigurations() {
+        return configurations;
+    }
+
+    @XmlElement
+    public void setConfigurations(Configurations configurations) {
+        this.configurations = configurations;
+    }
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Property.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/Property.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.product;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean to represent a property.
+ *
+ * This is used to
+ * [1] Capture build-time product file property data from distribution pom file.
+ * [2] Write property data to carbon.product file.
+ *
+ * @since 3.1.0
+ */
+@XmlRootElement
+public class Property {
+
+    private String name;
+    private Boolean value;
+
+    @SuppressWarnings("unused")
+    public Property() {}
+
+    public Property(String name, Boolean value) {
+        this.setName(name);
+        this.setValue(value);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @XmlAttribute
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Boolean getValue() {
+        return value;
+    }
+
+    @XmlAttribute
+    public void setValue(Boolean value) {
+        this.value = value;
+    }
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/config/ProductConfig.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/config/ProductConfig.java
@@ -45,7 +45,6 @@ public class ProductConfig {
     private String id = ProductFile.Product.ID;
     private String application = ProductFile.Product.APPLICATION;
     private String version; // If not set in project pom, carbon runtime version will be set by default.
-    private Boolean useFeatures = ProductFile.Product.USE_FEATURES;
     private Boolean includeLaunchers = ProductFile.Product.INCLUDE_LAUNCHERS;
     private ConfigIni configIni = new ConfigIni();
     private Launcher launcher = new Launcher();
@@ -95,15 +94,6 @@ public class ProductConfig {
     @XmlAttribute
     public void setVersion(String version) {
         this.version = version;
-    }
-
-    public Boolean getUseFeatures() {
-        return useFeatures;
-    }
-
-    @XmlAttribute
-    public void setUseFeatures(Boolean useFeatures) {
-        this.useFeatures = useFeatures;
     }
 
     public Boolean getIncludeLaunchers() {

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/config/ProductConfig.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/config/ProductConfig.java
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.product.config;
+
+import org.wso2.maven.p2.beans.product.ConfigIni;
+import org.wso2.maven.p2.beans.product.Launcher;
+import org.wso2.maven.p2.beans.product.Plugin;
+import org.wso2.maven.p2.beans.product.Property;
+import org.wso2.maven.p2.utils.P2Constants.ProductFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+/**
+ * Bean to represent product configurations.
+ *
+ * This is used to capture build-time product configuration
+ * data from distribution pom file.
+ *
+ * @since 3.1.0
+ */
+@XmlRootElement
+public class ProductConfig {
+
+    private String name = ProductFile.Product.NAME;
+    private String uid = ProductFile.Product.UID;
+    private String id = ProductFile.Product.ID;
+    private String application = ProductFile.Product.APPLICATION;
+    private String version; // If not set in project pom, carbon runtime version will be set by default.
+    private Boolean useFeatures = ProductFile.Product.USE_FEATURES;
+    private Boolean includeLaunchers = ProductFile.Product.INCLUDE_LAUNCHERS;
+    private ConfigIni configIni = new ConfigIni();
+    private Launcher launcher = new Launcher();
+    private List<Plugin> pluginConfig = this.getDefaultPluginConfig();
+    private List<Property> propertyConfig = this.getDefaultPropertyConfig();
+
+    public String getName() {
+        return name;
+    }
+
+    @XmlAttribute
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUid() {
+        return uid;
+    }
+
+    @XmlAttribute
+    public void setUid(String uid) {
+        this.uid = uid;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @XmlAttribute
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    @XmlAttribute
+    public void setApplication(String application) {
+        this.application = application;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    @XmlAttribute
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public Boolean getUseFeatures() {
+        return useFeatures;
+    }
+
+    @XmlAttribute
+    public void setUseFeatures(Boolean useFeatures) {
+        this.useFeatures = useFeatures;
+    }
+
+    public Boolean getIncludeLaunchers() {
+        return includeLaunchers;
+    }
+
+    @XmlAttribute
+    public void setIncludeLaunchers(Boolean includeLaunchers) {
+        this.includeLaunchers = includeLaunchers;
+    }
+
+    public ConfigIni getConfigIni() {
+        return configIni;
+    }
+
+    @XmlElement
+    public void setConfigIni(ConfigIni configIni) {
+        this.configIni = configIni;
+    }
+
+    public Launcher getLauncher() {
+        return launcher;
+    }
+
+    @XmlElement
+    public void setLauncher(Launcher launcher) {
+        this.launcher = launcher;
+    }
+
+    public List<Plugin> getPluginConfig() {
+        return pluginConfig;
+    }
+
+    @XmlTransient
+    @SuppressWarnings("unused")
+    public void setPluginConfig(List<Plugin> pluginConfig) {
+        this.pluginConfig = pluginConfig;
+    }
+
+    public List<Property> getPropertyConfig() {
+        return propertyConfig;
+    }
+
+    @XmlTransient
+    @SuppressWarnings("unused")
+    public void setPropertyConfig(List<Property> propertyConfig) {
+        this.propertyConfig = propertyConfig;
+    }
+
+    private List<Property> getDefaultPropertyConfig() {
+        List<Property> properties = new ArrayList<>();
+        // adding default property, value pairs
+        properties.add(new Property("org.eclipse.update.reconcile", false));
+        properties.add(new Property("org.eclipse.equinox.simpleconfigurator.useReference", true));
+        return properties;
+    }
+
+    private List<Plugin> getDefaultPluginConfig() {
+        List<Plugin> plugins = new ArrayList<>();
+        // adding default plugins wth default autoStart and startLevel configurations
+        plugins.add(new Plugin("org.eclipse.update.configurator", true, 1));
+        plugins.add(new Plugin("org.eclipse.equinox.simpleconfigurator", true, 1));
+        plugins.add(new Plugin("org.eclipse.equinox.ds", true, 2));
+        plugins.add(new Plugin("org.eclipse.equinox.common", true, 2));
+        plugins.add(new Plugin("org.eclipse.core.runtime", true, 4));
+        plugins.add(new Plugin("org.eclipse.equinox.p2.reconciler.dropins", true, 4));
+        return plugins;
+    }
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/config/ProductFileConfig.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/beans/product/config/ProductFileConfig.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.beans.product.config;
+
+import org.wso2.maven.p2.utils.P2Constants;
+
+/**
+ * Bean to represent build-time product file configurations.
+ *
+ * This is used to capture build-time product file configuration
+ * data from distribution pom file.
+ *
+ * @since 3.1.0
+ */
+public class ProductFileConfig {
+
+    private Float pdeVersion = P2Constants.ProductFile.PDE_VERSION;
+    private ProductConfig productConfig = new ProductConfig();
+
+    public Float getPdeVersion() {
+        return pdeVersion;
+    }
+
+    @SuppressWarnings("unused")
+    public void setPdeVersion(Float pdeVersion) {
+        this.pdeVersion = pdeVersion;
+    }
+
+    public ProductConfig getProductConfig() {
+        return productConfig;
+    }
+
+    @SuppressWarnings("unused")
+    public void setProductConfig(ProductConfig productConfig) {
+        this.productConfig = productConfig;
+    }
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/product/PublishProductMojo.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/product/PublishProductMojo.java
@@ -15,7 +15,6 @@
  */
 package org.wso2.maven.p2.product;
 
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -24,11 +23,15 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.sisu.equinox.launching.internal.P2ApplicationLauncher;
+import org.wso2.maven.p2.beans.product.config.ProductFileConfig;
 import org.wso2.maven.p2.utils.P2ApplicationLaunchManager;
+import org.wso2.maven.p2.utils.ProductFileUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Paths;
+import javax.xml.bind.JAXBException;
 
 /**
  * Publish a given product using the .product file to the repository.
@@ -54,6 +57,13 @@ public class PublishProductMojo extends AbstractMojo {
      */
     @Parameter
     private File productConfigurationFile;
+
+    /**
+     * Bean to capture build-time product file customizations
+     * from pom level configurations.
+     */
+    @Parameter
+    private ProductFileConfig productFileConfig = new ProductFileConfig();
 
     @Component
     private P2ApplicationLauncher launcher;
@@ -83,14 +93,31 @@ public class PublishProductMojo extends AbstractMojo {
     /**
      * Perform the product publish action.
      *
-     * @throws MojoFailureException throws when the tool breaks for any configuration issues
-     * @throws IOException          throws if fail to read file canonical path.
+     * @throws MojoFailureException     throws when the tool breaks for any configuration issues.
+     * @throws MojoExecutionException   throws when any runtime exception occurs.
+     *                                  i.e: fail to read write file, fail to parse a configuration xml.
+     * @throws IOException              throws if fail to read file canonical path.
      */
-    private void publishProduct() throws MojoFailureException, IOException {
-        P2ApplicationLaunchManager p2LaunchManager = new P2ApplicationLaunchManager(this.launcher);
+    private void publishProduct() throws MojoFailureException, MojoExecutionException, IOException {
+        P2ApplicationLaunchManager p2LaunchManager = new P2ApplicationLaunchManager(launcher);
         p2LaunchManager.setWorkingDirectory(project.getBasedir());
         p2LaunchManager.setApplicationName("org.eclipse.equinox.p2.publisher.ProductPublisher");
-        p2LaunchManager.addPublishProductArguments(repositoryURL, productConfigurationFile, executable);
+
+        if (productConfigurationFile != null) {
+            p2LaunchManager.addPublishProductArguments(repositoryURL, productConfigurationFile, executable);
+        } else {
+            // going ahead with a dynamically generated product file during build-time
+            File productFile = Paths.get(ProductFileUtils.getProductFilePath(project)).toFile();
+            if (!productFile.exists()) {
+                try {
+                    ProductFileUtils.generateProductFile(productFileConfig, project);
+                } catch (JAXBException e) {
+                    throw new MojoExecutionException("Cannot proceed as there is an error in " +
+                            "writing configurations to product file.", e);
+                }
+            }
+            p2LaunchManager.addPublishProductArguments(repositoryURL, productFile, executable);
+        }
         p2LaunchManager.performAction(forkedProcessTimeoutInSeconds);
     }
 }

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/P2Constants.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/P2Constants.java
@@ -25,8 +25,7 @@ public class P2Constants {
     /**
      * Prevent instantiating the Constants class.
      */
-    private P2Constants() {
-    }
+    private P2Constants() {}
 
     public static final String DEFAULT_PROFILE_ID = "WSO2CarbonProfile";
     public static final String P2_DIRECTORY = "@config.dir/../lib/p2/";
@@ -50,5 +49,37 @@ public class P2Constants {
         public static final String INSTALLIU = "-installIU";
     }
 
+    /**
+     * Constants class related to product file default settings.
+     */
+    public static class ProductFile {
+        public static final String NAME = "carbon.product";
+        public static final String TARGET_DIRECTORY = "target";
+        public static final Float XML_VERSION = 1.0F;
+        public static final Float PDE_VERSION = 3.5F;
 
+        /**
+         * Constants class related to Product element default settings of product file.
+         */
+        public static class Product {
+            public static final String NAME = "Carbon Product";
+            public static final String UID = "carbon.product.id";
+            public static final String ID = "carbon.product";
+            public static final String APPLICATION = "carbon.application";
+            public static final String RUNTIME_FEATURE = "org.wso2.carbon.runtime";
+            public static final Boolean USE_FEATURES = true;
+            public static final Boolean INCLUDE_LAUNCHERS = true;
+            public static final String CONFIG_INI_USE = "default";
+            public static final String LAUNCHER_NAME = "eclipse";
+        }
+
+        /**
+         * Constants class related to default character replacement settings of
+         * version values appearing in a product file.
+         */
+        public static class Feature {
+            public static final String VERSION_CHAR_REPLACEMENT = ".";
+            public static final String VERSION_CHAR_REPLACED = "-";
+        }
+    }
 }

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/P2Constants.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/P2Constants.java
@@ -67,7 +67,7 @@ public class P2Constants {
             public static final String ID = "carbon.product";
             public static final String APPLICATION = "carbon.application";
             public static final String RUNTIME_FEATURE = "org.wso2.carbon.runtime";
-            public static final Boolean USE_FEATURES = true;
+            public static final Boolean USE_FEATURES = false;
             public static final Boolean INCLUDE_LAUNCHERS = true;
             public static final String CONFIG_INI_USE = "default";
             public static final String LAUNCHER_NAME = "eclipse";

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/ProductFileUtils.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/ProductFileUtils.java
@@ -1,0 +1,143 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.maven.p2.utils;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.wso2.maven.p2.beans.product.Configurations;
+import org.wso2.maven.p2.beans.product.Product;
+import org.wso2.maven.p2.beans.product.config.ProductConfig;
+import org.wso2.maven.p2.beans.product.config.ProductFileConfig;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+
+/**
+ * Utility class for helper functions in generating and reading a product file at build-time.
+ *
+ * This class is to be used by publish-product and generate-runtime maven goals.
+ *
+ * @since 3.1.0
+ */
+public class ProductFileUtils {
+
+    /**
+     * Write Product bean as an XML to a product file.
+     *
+     * @param productFileConfig productFileConfig bean as read from project pom.
+     * @param mavenProject mavenProject bean as read from project pom.
+     * @throws javax.xml.bind.JAXBException Is thrown if an error occurs in writing configurations into product file.
+     */
+    public static void generateProductFile(ProductFileConfig productFileConfig,
+                                           MavenProject mavenProject)
+                                           throws JAXBException, MojoExecutionException, IOException {
+        // validating version and featureConfig values captured from project pom
+        ProductConfig validatedProductConfig = ProductFileUtils
+                .validateProductConfig(productFileConfig.getProductConfig(), mavenProject);
+
+        // populating a product instance with validated values for writing to a product file
+        Product product = new Product();
+
+        product.setName(validatedProductConfig.getName());
+        product.setUid(validatedProductConfig.getUid());
+        product.setId(validatedProductConfig.getId());
+        product.setApplication(validatedProductConfig.getApplication());
+        product.setVersion(validateProductVersion(validatedProductConfig.getVersion()));
+        product.setUseFeatures(validatedProductConfig.getUseFeatures());
+        product.setIncludeLaunchers(validatedProductConfig.getIncludeLaunchers());
+        product.setConfigIni(validatedProductConfig.getConfigIni());
+        product.setLauncher(validatedProductConfig.getLauncher());
+        product.setConfigurations(new Configurations(validatedProductConfig.getPluginConfig(),
+                validatedProductConfig.getPropertyConfig()));
+
+        // writing to a product file
+        StringWriter stringWriter = new StringWriter();
+        stringWriter.append("<?xml version=\"").append(P2Constants.ProductFile.XML_VERSION.toString())
+                    .append("\" encoding=\"").append(P2Constants.DEFAULT_ENCODING).append("\"?>")
+                    .append(System.lineSeparator())
+                    .append("<?pde version=\"").append(productFileConfig.getPdeVersion().toString()).append("\"?>")
+                    .append(System.lineSeparator());
+
+        JAXBContext jaxbContext = JAXBContext.newInstance(Product.class);
+        Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+
+        jaxbMarshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
+        jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        jaxbMarshaller.marshal(product, stringWriter);
+
+        Files.write(Paths.get(ProductFileUtils.getProductFilePath(mavenProject)),
+                stringWriter.toString().getBytes(Charset.forName(P2Constants.DEFAULT_ENCODING)));
+    }
+
+    public static String getProductFilePath(MavenProject mavenProject) throws MojoExecutionException {
+        if (mavenProject == null) {
+            throw new MojoExecutionException("Unable to read maven project for finding project path.");
+        } else {
+            return mavenProject.getBasedir().getAbsolutePath() + File.separator +
+                P2Constants.ProductFile.TARGET_DIRECTORY + File.separator + P2Constants.ProductFile.NAME;
+        }
+    }
+
+    private static ProductConfig
+        validateProductConfig(ProductConfig productConfig, MavenProject mavenProject)
+            throws MojoExecutionException {
+        if (productConfig.getVersion() == null) {
+            productConfig.setVersion(ProductFileUtils.getDependencyVersion(mavenProject,
+                    P2Constants.ProductFile.Product.RUNTIME_FEATURE));
+        }
+        return productConfig;
+    }
+
+    private static String validateProductVersion(String version) {
+        if (version != null && !version.isEmpty() &&
+                version.contains(P2Constants.ProductFile.Feature.VERSION_CHAR_REPLACED)) {
+            version = version.replaceAll(P2Constants.ProductFile.Feature.VERSION_CHAR_REPLACED,
+                    P2Constants.ProductFile.Feature.VERSION_CHAR_REPLACEMENT);
+        }
+        return version;
+    }
+
+    private static String getDependencyVersion(MavenProject mavenProject,
+                                               String dependency) throws MojoExecutionException {
+        if (mavenProject == null) {
+            throw new MojoExecutionException("Unable to read maven project for finding dependencies.");
+        } else if (dependency == null || dependency.isEmpty()) {
+            throw new MojoExecutionException("Unable to find version for invalid dependency value.");
+        } else {
+            Artifact selectedArtifact = mavenProject.getDependencyArtifacts()
+                    .stream()
+                    .filter(artifact -> artifact.getArtifactId().contains(dependency))
+                    .findFirst()
+                    .orElseThrow(() -> new MojoExecutionException("Unable to find version as there seems to be " +
+                            "no pom based configuration for the provided dependency."));
+
+            String dependencyVersion = selectedArtifact.getBaseVersion();
+            if (dependencyVersion == null || dependencyVersion.isEmpty()) {
+                throw new MojoExecutionException("Unable to find version for the provided dependency.");
+            }
+            return dependencyVersion;
+        }
+    }
+}

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/ProductFileUtils.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/ProductFileUtils.java
@@ -65,7 +65,6 @@ public class ProductFileUtils {
         product.setId(validatedProductConfig.getId());
         product.setApplication(validatedProductConfig.getApplication());
         product.setVersion(validateProductVersion(validatedProductConfig.getVersion()));
-        product.setUseFeatures(validatedProductConfig.getUseFeatures());
         product.setIncludeLaunchers(validatedProductConfig.getIncludeLaunchers());
         product.setConfigIni(validatedProductConfig.getConfigIni());
         product.setLauncher(validatedProductConfig.getLauncher());

--- a/docs/CarbonFeaturePlugin.md
+++ b/docs/CarbonFeaturePlugin.md
@@ -67,13 +67,16 @@ A sample pom.xml file configuration of the `publish-product` Maven goal is shown
                         <!-- configurations related to this goal go under here -->
                                 <!-- [1] product file related configurations :
                                 
-                                        You can keep no configuration at all. This would check if a product file 
-                                        already exists in the target directory of the project. If not, plugin 
-                                        will dynamically generate a product file during build-time with 
-                                        default settings and use it. But if <productConfigurationFile> element is 
-                                        present, that will override any other configuration related to a product file 
-                                        and refer to any already existing (static) product file located at a path 
+                                        You can keep no configuration at all. This would check if 
+                                        a product file already exists in the target directory 
+                                        of the project. If not, plugin will dynamically generate 
+                                        a product file during build-time with default settings and 
+                                        use it. But if <productConfigurationFile> element is 
+                                        present, that will override any other configuration related 
+                                        to a product file and refer to any already existing 
+                                        (static) product file located at a path 
                                         specified by the value of the element.
+                                        
                                         For example, please refer to the following. -->
                                         
                                                 <productConfigurationFile>
@@ -81,7 +84,8 @@ A sample pom.xml file configuration of the `publish-product` Maven goal is shown
                                                 </productConfigurationFile>
 
                                         <!-- following is optional and can be used if customization 
-                                        is required for a dynamically generated product file during build-time. -->
+                                        is required for a dynamically generated product file 
+                                        during build-time. -->
                                         
                                                 <productFileConfig>
                                                         <!-- see `productFileConfig` section for 
@@ -97,7 +101,8 @@ A sample pom.xml file configuration of the `publish-product` Maven goal is shown
                                 <!-- [3] Carbon feature repository based configurations : -->
                                 
                                                 <repositoryURL>
-                                                        <!-- Carbon feature repository path is given here. -->
+                                                        <!-- Carbon feature repository path 
+                                                        is given here. -->
                                                 </repositoryURL>
                                                 
                 </configuration>
@@ -136,7 +141,8 @@ In the meantime, each element is described as follows.
                 <!-- [4] application (String): If not set, default value is 'carbon.application'. -->
                 <application>.....</application>
                 
-                <!-- [5] version (String): If not set, carbon runtime version will be taken as default value. -->
+                <!-- [5] version (String): If not set, carbon runtime version will be 
+                taken as default value. -->
                 <version>.....</version>
             
                 <!-- [6] includeLaunchers (true or false): If not set, default value is 'true'. -->
@@ -208,13 +214,16 @@ A sample pom.xml file configuration of the `generate-runtime` Maven goal is show
                         <!-- configurations related to this goal go under here -->
                                 <!-- [1] product file related configurations : 
                                 
-                                You can keep no configuration at all. This would check if a product file 
-                                already exists in the target directory of the project. If not, plugin 
-                                will dynamically generate a product file during build-time with 
-                                default settings and use it. But if <productConfigurationFile> element is 
-                                present, that will override any other configuration related to a product file 
-                                and refer to any already existing (static) product file located at a path 
+                                You can keep no configuration at all. This would check if 
+                                a product file already exists in the target directory 
+                                of the project. If not, plugin will dynamically generate 
+                                a product file during build-time with default settings and 
+                                use it. But if <productConfigurationFile> element is 
+                                present, that will override any other configuration related 
+                                to a product file and refer to any already existing 
+                                (static) product file located at a path 
                                 specified by the value of the element.
+                                                                        
                                 For example, please refer to the following. -->
                                                                         
                                         <productConfigurationFile>
@@ -222,7 +231,8 @@ A sample pom.xml file configuration of the `generate-runtime` Maven goal is show
                                         </productConfigurationFile>
                                 
                                 <!-- following is optional and can be used if customization 
-                                is required for a dynamically generated product file during build-time. -->
+                                is required for a dynamically generated 
+                                product file during build-time. -->
                                                                         
                                         <productFileConfig>
                                                 <!-- see `productFileConfig` section for 
@@ -232,14 +242,16 @@ A sample pom.xml file configuration of the `generate-runtime` Maven goal is show
                                 <!-- [2] Carbon feature repository based configurations : -->
                                 
                                         <repositoryURL>
-                                                <!-- Carbon feature repository path is given here. -->
+                                                <!-- Carbon feature repository path 
+                                                is given here. -->
                                         </repositoryURL>
                                 
-                                <!-- [3] Target location for the carbon features to be copied in server pack : -->
+                                <!-- [3] Target location for the carbon features 
+                                to be copied in server pack : -->
                                 
                                         <targetPath>
-                                                <!-- Target location for the carbon features to be copied 
-                                                in server pack is given here. -->
+                                                <!-- Target location for the carbon features to be 
+                                                copied in server pack is given here. -->
                                         </targetPath>
                                         
                                 <!-- [4] Runtime type : -->
@@ -284,7 +296,8 @@ In the meantime, each element is described as follows.
                     <!-- [4] application (String): If not set, default value is 'carbon.application'. -->
                     <application>.....</application>
                     
-                    <!-- [5] version (String): If not set, carbon runtime version will be taken as default value. -->
+                    <!-- [5] version (String): If not set, carbon runtime version will be 
+                    taken as default value. -->
                     <version>.....</version>
                 
                     <!-- [6] includeLaunchers (true or false): If not set, default value is 'true'. -->

--- a/docs/CarbonFeaturePlugin.md
+++ b/docs/CarbonFeaturePlugin.md
@@ -52,6 +52,327 @@ A sample pom.xml file configuration of the `generate` Maven goal is shown below.
 
  NOT MANDATORY.
  Example: `<deleteOldRuntimeFiles>false</deleteOldRuntimeFiles>`.
+ 
+### Configuring the publish-product Maven goal
+
+A sample pom.xml file configuration of the `publish-product` Maven goal is shown below.
+
+      <execution>
+                <id>publishing products</id>
+                <phase>package</phase>
+                <goals>
+                        <goal>publish-product</goal>
+                </goals>
+                <configuration>
+                        <!-- configurations related to this goal go under here -->
+                                <!-- [1] product file related configurations :
+                                
+                                        You can keep no configuration at all. This would check if a product file 
+                                        already exists in the target directory of the project. If not, plugin 
+                                        will dynamically generate a product file during build-time with 
+                                        default settings and use it. But if <productConfigurationFile> element is 
+                                        present, that will override any other configuration related to a product file 
+                                        and refer to any already existing (static) product file located at a path 
+                                        specified by the value of the element.
+                                        For example, please refer to the following. -->
+                                        
+                                                <productConfigurationFile>
+                                                        ${basedir}/carbon.product
+                                                </productConfigurationFile>
+
+                                        <!-- following is optional and can be used if customization 
+                                        is required for a dynamically generated product file during build-time. -->
+                                        
+                                                <productFileConfig>
+                                                        <!-- see `productFileConfig` section for 
+                                                        available customization options -->
+                                                </productFileConfig>
+                                        
+                                <!-- [2] product-publishing executable related configurations : -->
+                                
+                                                <executable>
+                                                        <!-- executable path is given here. -->
+                                                </executable>
+                                        
+                                <!-- [3] Carbon feature repository based configurations : -->
+                                
+                                                <repositoryURL>
+                                                        <!-- Carbon feature repository path is given here. -->
+                                                </repositoryURL>
+                                                
+                </configuration>
+      </execution>
+      
+You can add any mandatory or optional configuration elements related to this goal under \<configuration\> element as depicted above.
+In the meantime, each element is described as follows.
+ 
+1. `productConfigurationFile`: With respect to product file related configurations, this element is mandatory if you are choosing to refer 
+    to any already existing (static) product file in publishing the product. The element will contain absolute path to such product file as value.
+    
+    Note: You can instead go ahead with referring to a dynamically generated product file during build-time in achieving "publish-product" goal.
+    This can be achieved by having no configurations at all in the pom, so that a product file (if no such file already exists in the target directory 
+    of the project) will be dynamically generated during build-time with default settings. This is an improvement added to carbon-feature-plugin such that 
+    no further manual intervention is required in updating a statically maintained product file during build-time for the release process as 
+    in the case of \<productConfigurationFile\> setting.
+    
+2. `productFileConfig`: This is an optional configuration that you can set if and only if customization is required for a 
+    dynamically generated product file during build-time over provided default settings.
+    
+    Available customization options:
+    
+    \<productFileConfig\>
+    
+        <!-- [1] pdeVersion (Number): Default value is 3.5. -->
+        <pdeVersion>.....</pdeVersion>
+        
+        <productConfig>
+        
+                <!-- [2] name (String): If not set, default value is 'Carbon Product'. -->
+                <name>.....</name>
+            
+                <!-- [3] uid (String): If not set, default value is 'carbon.product.id'. -->
+                <uid>.....</uid>
+            
+                <!-- [4] application (String): If not set, default value is 'carbon.application'. -->
+                <application>.....</application>
+                
+                <!-- [5] version (String): If not set, carbon runtime version will be taken as default value. -->
+                <version>.....</version>
+            
+                <!-- [6] useFeatures (true or false): If not set, default value is 'true'. -->
+                <useFeatures>.....</useFeatures>
+            
+                <!-- [7] includeLaunchers (true or false): If not set, default value is 'true'. -->
+                <includeLaunchers>.....</includeLaunchers>
+                
+                <!-- [8] configIni: If not set, default value for use is 'default'. -->
+                <configIni>
+                        <use>.....</use>
+                </configIni>
+                
+                <!-- [9] launcher: If not set, default value for name is 'eclipse'. -->
+                <launcher>
+                        <name>eclipse</name>
+                </launcher>
+                
+                <!-- [10] featureConfig: If not set, by default, 
+                featureConfig will hold 'org.wso2.carbon.runtime' feature. -->
+                <featureConfig>
+                        <feature>
+                                <id>.....</id>
+                                <version>.....</version>
+                        </feature>
+                        .....
+                </featureConfig>
+                
+                <!-- [11] pluginConfig: If not set, by default, 
+                pluginConfig will hold 6 plugins, namely 
+                org.eclipse.core.runtime, org.eclipse.equinox.common,
+                org.eclipse.equinox.ds, org.eclipse.equinox.p2.reconciler.dropins, 
+                org.eclipse.equinox.simpleconfigurator,
+                and org.eclipse.update.configurator. -->
+                <pluginConfig>
+                        <plugin>
+                                <id>.....</id>
+                                <autoStart>.....</autoStart>
+                                <startLevel>.....</startLevel>
+                        </plugin>
+                        .....                    
+                        <plugin></plugin>
+                </pluginConfig>
+                
+                <!-- [12] propertyConfig: If not set, by default, 
+                propertyConfig will hold 2 properties, namely org.eclipse.update.reconcile and 
+                org.eclipse.update.recon. -->
+                <propertyConfig>
+                        <property>
+                                <name>.....</name>
+                                <value>.....</value>
+                        </property>
+                        .....
+                </propertyConfig>
+        </productConfig>
+        
+    \</productFileConfig\>
+    
+3. `executable`: product-publishing executable related configurations.
+
+        <executable>
+                <!-- product-publishing executable path is given here. -->
+        </executable>
+    
+4. `repositoryURL`: Carbon feature repository based configurations.
+
+        <repositoryURL>
+                <!-- Carbon feature repository path is given here. -->
+        </repositoryURL>
+
+### Configuring the generate-runtime Maven goal
+
+A sample pom.xml file configuration of the `generate-runtime` Maven goal is shown below.
+
+      <execution>
+                <id>materialize-product</id>
+                <phase>package</phase>
+                <goals>
+                        <goal>generate-runtime</goal>
+                </goals>
+                <configuration>
+                        <!-- configurations related to this goal go under here -->
+                                <!-- [1] product file related configurations : 
+                                
+                                You can keep no configuration at all. This would check if a product file 
+                                already exists in the target directory of the project. If not, plugin 
+                                will dynamically generate a product file during build-time with 
+                                default settings and use it. But if <productConfigurationFile> element is 
+                                present, that will override any other configuration related to a product file 
+                                and refer to any already existing (static) product file located at a path 
+                                specified by the value of the element.
+                                For example, please refer to the following. -->
+                                                                        
+                                        <productConfigurationFile>
+                                                ${basedir}/carbon.product
+                                        </productConfigurationFile>
+                                
+                                <!-- following is optional and can be used if customization 
+                                is required for a dynamically generated product file during build-time. -->
+                                                                        
+                                        <productFileConfig>
+                                                <!-- see `productFileConfig` section for 
+                                                available customization options -->
+                                        </productFileConfig>
+                                        
+                                <!-- [2] Carbon feature repository based configurations : -->
+                                
+                                        <repositoryURL>
+                                                <!-- Carbon feature repository path is given here. -->
+                                        </repositoryURL>
+                                
+                                <!-- [3] Target location for the carbon features to be copied in server pack : -->
+                                
+                                        <targetPath>
+                                                <!-- Target location for the carbon features to be copied 
+                                                in server pack is given here. -->
+                                        </targetPath>
+                                        
+                                <!-- [4] Runtime type : -->
+                                
+                                        <runtime>
+                                                <!-- Runtime type is given here. -->
+                                        </runtime>
+                                        
+                </configuration>
+      </execution>
+      
+You can add any mandatory or optional configuration elements related to this goal under \<configuration\> element as depicted above.
+In the meantime, each element is described as follows.
+
+1. `productConfigurationFile`: With respect to product file related configurations, this element is mandatory if you are choosing to refer 
+    to any already existing (static) product file in publishing the product. The element will contain absolute path to such product file as value.
+    
+    Note: You can instead go ahead with referring to a dynamically generated product file during build-time in achieving "publish-product" goal.
+    This can be achieved by having no configurations at all in the pom, so that a product file (if no such file already exists in the target directory 
+    of the project) will be dynamically generated during build-time with default settings. This is an improvement added to carbon-feature-plugin such that 
+    no further manual intervention is required in updating a statically maintained product file during build-time for the release process as 
+    in the case of \<productConfigurationFile\> setting.
+    
+2. `productFileConfig`: This is an optional configuration that you can set if and only if customization is required for a 
+    dynamically generated product file during build-time over provided default settings.
+    
+    Available customization options:
+    
+    \<productFileConfig\>
+    
+        <!-- [1] pdeVersion (Number): Default value is 3.5. -->
+        <pdeVersion>.....</pdeVersion>
+        
+        <productConfig>
+        
+                <!-- [2] name (String): If not set, default value is 'Carbon Product'. -->
+                <name>.....</name>
+            
+                <!-- [3] uid (String): If not set, default value is 'carbon.product.id'. -->
+                <uid>.....</uid>
+            
+                <!-- [4] application (String): If not set, default value is 'carbon.application'. -->
+                <application>.....</application>
+                
+                <!-- [5] version (String): If not set, carbon runtime version will be taken as default value. -->
+                <version>.....</version>
+            
+                <!-- [6] useFeatures (true or false): If not set, default value is 'true'. -->
+                <useFeatures>.....</useFeatures>
+            
+                <!-- [7] includeLaunchers (true or false): If not set, default value is 'true'. -->
+                <includeLaunchers>.....</includeLaunchers>
+                
+                <!-- [8] configIni: If not set, default value for use is 'default'. -->
+                <configIni>
+                        <use>.....</use>
+                </configIni>
+                
+                <!-- [9] launcher: If not set, default value for name is 'eclipse'. -->
+                <launcher>
+                        <name>eclipse</name>
+                </launcher>
+                
+                <!-- [10] featureConfig: If not set, by default, 
+                featureConfig will hold 'org.wso2.carbon.runtime' feature. -->
+                <featureConfig>
+                        <feature>
+                                <id>.....</id>
+                                <version>.....</version>
+                        </feature>
+                        .....
+                </featureConfig>
+                
+                <!-- [11] pluginConfig: If not set, by default, 
+                pluginConfig will hold 6 plugins, namely 
+                org.eclipse.core.runtime, org.eclipse.equinox.common,
+                org.eclipse.equinox.ds, org.eclipse.equinox.p2.reconciler.dropins, 
+                org.eclipse.equinox.simpleconfigurator,
+                and org.eclipse.update.configurator. -->
+                <pluginConfig>
+                        <plugin>
+                                <id>.....</id>
+                                <autoStart>.....</autoStart>
+                                <startLevel>.....</startLevel>
+                        </plugin>
+                        .....                    
+                        <plugin></plugin>
+                </pluginConfig>
+                
+                <!-- [12] propertyConfig: If not set, by default, 
+                propertyConfig will hold 2 properties, namely org.eclipse.update.reconcile and 
+                org.eclipse.update.recon. -->
+                <propertyConfig>
+                        <property>
+                                <name>.....</name>
+                                <value>.....</value>
+                        </property>
+                        .....
+                </propertyConfig>
+        </productConfig>
+        
+    \</productFileConfig\>
+    
+3. `repositoryURL`: Carbon feature repository based configurations.
+
+        <repositoryURL>
+                <!-- Carbon feature repository path is given here. -->
+        </repositoryURL>
+        
+4. `targetPath`: Target location for the carbon features to be copied in server pack.
+
+        <targetPath>
+                <!-- Target location for the carbon features to be copied in server pack is given here. -->
+        </targetPath>
+    
+5. `runtime`: Runtime type.
+    
+        <runtime>
+                <!-- Runtime type is given here. -->
+        </runtime>
 
 ### Configuring the uninstall Maven goal
 

--- a/docs/CarbonFeaturePlugin.md
+++ b/docs/CarbonFeaturePlugin.md
@@ -139,33 +139,20 @@ In the meantime, each element is described as follows.
                 <!-- [5] version (String): If not set, carbon runtime version will be taken as default value. -->
                 <version>.....</version>
             
-                <!-- [6] useFeatures (true or false): If not set, default value is 'true'. -->
-                <useFeatures>.....</useFeatures>
-            
-                <!-- [7] includeLaunchers (true or false): If not set, default value is 'true'. -->
+                <!-- [6] includeLaunchers (true or false): If not set, default value is 'true'. -->
                 <includeLaunchers>.....</includeLaunchers>
                 
-                <!-- [8] configIni: If not set, default value for use is 'default'. -->
+                <!-- [7] configIni: If not set, default value for use is 'default'. -->
                 <configIni>
                         <use>.....</use>
                 </configIni>
                 
-                <!-- [9] launcher: If not set, default value for name is 'eclipse'. -->
+                <!-- [8] launcher: If not set, default value for name is 'eclipse'. -->
                 <launcher>
                         <name>eclipse</name>
                 </launcher>
                 
-                <!-- [10] featureConfig: If not set, by default, 
-                featureConfig will hold 'org.wso2.carbon.runtime' feature. -->
-                <featureConfig>
-                        <feature>
-                                <id>.....</id>
-                                <version>.....</version>
-                        </feature>
-                        .....
-                </featureConfig>
-                
-                <!-- [11] pluginConfig: If not set, by default, 
+                <!-- [9] pluginConfig: If not set, by default, 
                 pluginConfig will hold 6 plugins, namely 
                 org.eclipse.core.runtime, org.eclipse.equinox.common,
                 org.eclipse.equinox.ds, org.eclipse.equinox.p2.reconciler.dropins, 
@@ -181,7 +168,7 @@ In the meantime, each element is described as follows.
                         <plugin></plugin>
                 </pluginConfig>
                 
-                <!-- [12] propertyConfig: If not set, by default, 
+                <!-- [10] propertyConfig: If not set, by default, 
                 propertyConfig will hold 2 properties, namely org.eclipse.update.reconcile and 
                 org.eclipse.update.recon. -->
                 <propertyConfig>
@@ -280,80 +267,67 @@ In the meantime, each element is described as follows.
     dynamically generated product file during build-time over provided default settings.
     
     Available customization options:
-    
+        
     \<productFileConfig\>
-    
-        <!-- [1] pdeVersion (Number): Default value is 3.5. -->
-        <pdeVersion>.....</pdeVersion>
         
-        <productConfig>
-        
-                <!-- [2] name (String): If not set, default value is 'Carbon Product'. -->
-                <name>.....</name>
+            <!-- [1] pdeVersion (Number): Default value is 3.5. -->
+            <pdeVersion>.....</pdeVersion>
             
-                <!-- [3] uid (String): If not set, default value is 'carbon.product.id'. -->
-                <uid>.....</uid>
+            <productConfig>
             
-                <!-- [4] application (String): If not set, default value is 'carbon.application'. -->
-                <application>.....</application>
+                    <!-- [2] name (String): If not set, default value is 'Carbon Product'. -->
+                    <name>.....</name>
                 
-                <!-- [5] version (String): If not set, carbon runtime version will be taken as default value. -->
-                <version>.....</version>
+                    <!-- [3] uid (String): If not set, default value is 'carbon.product.id'. -->
+                    <uid>.....</uid>
+                
+                    <!-- [4] application (String): If not set, default value is 'carbon.application'. -->
+                    <application>.....</application>
+                    
+                    <!-- [5] version (String): If not set, carbon runtime version will be taken as default value. -->
+                    <version>.....</version>
+                
+                    <!-- [6] includeLaunchers (true or false): If not set, default value is 'true'. -->
+                    <includeLaunchers>.....</includeLaunchers>
+                    
+                    <!-- [7] configIni: If not set, default value for use is 'default'. -->
+                    <configIni>
+                            <use>.....</use>
+                    </configIni>
+                    
+                    <!-- [8] launcher: If not set, default value for name is 'eclipse'. -->
+                    <launcher>
+                            <name>eclipse</name>
+                    </launcher>
+                    
+                    <!-- [9] pluginConfig: If not set, by default, 
+                    pluginConfig will hold 6 plugins, namely 
+                    org.eclipse.core.runtime, org.eclipse.equinox.common,
+                    org.eclipse.equinox.ds, org.eclipse.equinox.p2.reconciler.dropins, 
+                    org.eclipse.equinox.simpleconfigurator,
+                    and org.eclipse.update.configurator. -->
+                    <pluginConfig>
+                            <plugin>
+                                    <id>.....</id>
+                                    <autoStart>.....</autoStart>
+                                    <startLevel>.....</startLevel>
+                            </plugin>
+                            .....                    
+                            <plugin></plugin>
+                    </pluginConfig>
+                    
+                    <!-- [10] propertyConfig: If not set, by default, 
+                    propertyConfig will hold 2 properties, namely org.eclipse.update.reconcile and 
+                    org.eclipse.update.recon. -->
+                    <propertyConfig>
+                            <property>
+                                    <name>.....</name>
+                                    <value>.....</value>
+                            </property>
+                            .....
+                    </propertyConfig>
+            </productConfig>
             
-                <!-- [6] useFeatures (true or false): If not set, default value is 'true'. -->
-                <useFeatures>.....</useFeatures>
-            
-                <!-- [7] includeLaunchers (true or false): If not set, default value is 'true'. -->
-                <includeLaunchers>.....</includeLaunchers>
-                
-                <!-- [8] configIni: If not set, default value for use is 'default'. -->
-                <configIni>
-                        <use>.....</use>
-                </configIni>
-                
-                <!-- [9] launcher: If not set, default value for name is 'eclipse'. -->
-                <launcher>
-                        <name>eclipse</name>
-                </launcher>
-                
-                <!-- [10] featureConfig: If not set, by default, 
-                featureConfig will hold 'org.wso2.carbon.runtime' feature. -->
-                <featureConfig>
-                        <feature>
-                                <id>.....</id>
-                                <version>.....</version>
-                        </feature>
-                        .....
-                </featureConfig>
-                
-                <!-- [11] pluginConfig: If not set, by default, 
-                pluginConfig will hold 6 plugins, namely 
-                org.eclipse.core.runtime, org.eclipse.equinox.common,
-                org.eclipse.equinox.ds, org.eclipse.equinox.p2.reconciler.dropins, 
-                org.eclipse.equinox.simpleconfigurator,
-                and org.eclipse.update.configurator. -->
-                <pluginConfig>
-                        <plugin>
-                                <id>.....</id>
-                                <autoStart>.....</autoStart>
-                                <startLevel>.....</startLevel>
-                        </plugin>
-                        .....                    
-                        <plugin></plugin>
-                </pluginConfig>
-                
-                <!-- [12] propertyConfig: If not set, by default, 
-                propertyConfig will hold 2 properties, namely org.eclipse.update.reconcile and 
-                org.eclipse.update.recon. -->
-                <propertyConfig>
-                        <property>
-                                <name>.....</name>
-                                <value>.....</value>
-                        </property>
-                        .....
-                </propertyConfig>
-        </productConfig>
-        
     \</productFileConfig\>
     
 3. `repositoryURL`: Carbon feature repository based configurations.


### PR DESCRIPTION
This feature resolves #56 and adds an improvement to carbon-feature-plugin in supporting a dynamically generated product file for the reference of publish-product and generate-runtime maven goals. A dynamically generated product file during build-time overcomes the issue of having to manually update a statically maintained product file with version-bumps for a release-build, thus contributing to a fully-automated release process.