### PR TITLE
Update runtime feature name to osgi runtime feature

### DIFF
--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/P2Constants.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/P2Constants.java
@@ -66,7 +66,7 @@ public class P2Constants {
             public static final String UID = "carbon.product.id";
             public static final String ID = "carbon.product";
             public static final String APPLICATION = "carbon.application";
-            public static final String RUNTIME_FEATURE = "org.wso2.carbon.runtime";
+            public static final String OSGI_RUNTIME_FEATURE = "org.wso2.carbon.osgi";
             public static final Boolean USE_FEATURES = false;
             public static final Boolean INCLUDE_LAUNCHERS = true;
             public static final String CONFIG_INI_USE = "default";

--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/ProductFileUtils.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/ProductFileUtils.java
@@ -110,7 +110,7 @@ public class ProductFileUtils {
             MojoExecutionException {
         if (productConfig.getVersion() == null) {
             productConfig.setVersion(ProductFileUtils.getDependencyVersion(mavenProject, P2Constants.ProductFile
-                    .Product.RUNTIME_FEATURE));
+                    .Product.OSGI_RUNTIME_FEATURE));
         }
         return productConfig;
     }


### PR DESCRIPTION
- This is to rename org.wso2.carbon.runtime.feature to org.wso2.carbon.osgi.feature as "runtime" is now used for different purpose in C5 based products
- This resolves the issue - https://github.com/wso2/carbon-kernel/issues/1262