### PR TITLE
Fix feature uninstall bug

### DIFF
--- a/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/P2ApplicationLaunchManager.java
+++ b/carbon-feature-plugin/src/main/java/org/wso2/maven/p2/utils/P2ApplicationLaunchManager.java
@@ -111,9 +111,9 @@ public class P2ApplicationLaunchManager {
                 // the location of where the plug-ins and features will be stored. This value is only taken into account
                 // when a new profile is created. For an application where all the bundles are located into the
                 // plugins/ folder of the destination, set it to <destination>
-                // use a shared location for the install. The path defaults to ${user.home}/.p2
-                "-shared", Paths.get(destination + File.separator + "p2").toString(),
-                "-destination", Paths.get(destination + File.separator + profile).toString(),
+                // to support shared installation in carbon
+                "-shared", Paths.get(destination, "lib", "p2").toString(),
+                "-destination", Paths.get(destination, profile).toString(),
                 "-profile", profile
         );
     }


### PR DESCRIPTION
Fixed `-shared` P2ApplicationLauncher argument in `addArgumentsToUnInstallFeatures` method so that it points to the new location of `p2`
Resolves  #66